### PR TITLE
Enable HMR for the react files and hide the ClientApp files from the published project

### DIFF
--- a/ClientApp/js/react-notes.tsx
+++ b/ClientApp/js/react-notes.tsx
@@ -3,6 +3,10 @@ import * as ReactDOM from 'react-dom';
 
 import Notes from './react-notes/Notes';
 
+if (module.hot) {
+  module.hot.accept();
+}  
+
 ReactDOM.render(
   <Notes />,
   document.getElementById('react-notes-app')

--- a/ClientApp/package.json
+++ b/ClientApp/package.json
@@ -26,6 +26,7 @@
     "@types/classnames": "^2.2.6",
     "@types/react": "^16.4.9",
     "@types/react-dom": "^16.0.7",
+    "@types/webpack-env": "^1.13.6",
     "aspnet-webpack": "^3.0.0",
     "awesome-typescript-loader": "^5.2.0",
     "css-loader": "^1.0.0",

--- a/LeanAspNetCore.csproj
+++ b/LeanAspNetCore.csproj
@@ -2,11 +2,13 @@
 
   <PropertyGroup>
     <TargetFramework>netcoreapp2.1</TargetFramework>
-    <ClientAppFolder>ClientApp</ClientAppFolder>
+    <ClientAppFolder>ClientApp\</ClientAppFolder>
   </PropertyGroup>
 
   <ItemGroup>
-    <Folder Include="wwwroot\dist\" />
+    <!-- Don't publish the SPA source files, but do show them in the project files list -->
+    <Content Remove="$(ClientAppFolder)**" />
+    <None Include="$(ClientAppFolder)**" Exclude="$(ClientAppFolder)node_modules\**" />
   </ItemGroup>
 
   <ItemGroup>
@@ -25,7 +27,7 @@
 
     <!-- Include the newly-built files in the publish output -->
     <ItemGroup>
-      <DistFiles Include="$(ClientAppFolder)\wwwroot\dist\**" />
+      <DistFiles Include="wwwroot\dist\**"/>
       <ResolvedFileToPublish Include="@(DistFiles->'%(FullPath)')" Exclude="@(ResolvedFileToPublish)">
         <RelativePath>%(DistFiles.Identity)</RelativePath>
         <CopyToPublishDirectory>PreserveNewest</CopyToPublishDirectory>


### PR DESCRIPTION
Thanks for the great template. I just added two notifications because react HMR wasn't working (module was not hot enabled) and corrected the misconfigured ClientApp directory setting in CSProj when publishing.